### PR TITLE
Enable setting client nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ After execution, the program computes the probability that exactly $n^\prime$ no
 _Running example:_ To compute the scale-wise unreliability of UsCarrier topology when $|T|=5$, run:
 
 ```shell
-./main ../data/0186-real-UsCarrier.edgelist.txt ../data/0186-real-UsCarrier.edgelist.txt.prob ../data/src/0186-real-UsCarrier.edgelist.txt.bc5.src ../data/src/0186-real-UsCarrier.edgelist.txt
+./main ../data/0186-real-UsCarrier.edgelist.txt ../data/0189-real-UsCarrier.edgelist.txt.prob ../data/src/0189-real-UsCarrier.edgelist.txt.bc5.src ../data/src/0189-real-UsCarrier.edgelist.txt
 ```
 
 The baseline method can also be executed in the same way as follows:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ After execution, the program computes the probability that exactly $n^\prime$ no
 _Running example:_ To compute the scale-wise unreliability of UsCarrier topology when $|T|=5$, run:
 
 ```shell
-./main ../data/0186-real-UsCarrier.edgelist.txt ../data/0189-real-UsCarrier.edgelist.txt.prob ../data/src/0189-real-UsCarrier.edgelist.txt.bc5.src ../data/src/0189-real-UsCarrier.edgelist.txt
+./main ../data/0189-real-UsCarrier.edgelist.txt ../data/0189-real-UsCarrier.edgelist.txt.prob ../data/src/0189-real-UsCarrier.edgelist.txt.bc5.src ../data/src/0189-real-UsCarrier.edgelist.txt
 ```
 
 The baseline method can also be executed in the same way as follows:

--- a/README.md
+++ b/README.md
@@ -40,17 +40,17 @@ All data used in our experiments are in `data.tar.gz`. After extracting, `*.txt`
 The proposed method can be executed by the following command:
 
 ```shell
-./main [graph_file] [probability_file] [server_file] [order_file]
+./main [graph_file] [probability_file] [server_file] [order_file] <client_file>
 ```
 
-`[graph_file]`, `[probability_file]`, and `[server_file]` specify the path to the file describing the edgelist of the graph, each link's availability, and the list of server nodes, respectively. `[order_file]` specifies the path to the file describing the ordering among links. Note that we already computed the link order by the path-decomposition heuristics and wrote it on `*.txt`, so `[order_file]` can be specified with the same path as `[graph_file]` when reproducing the experimental results.
+`[graph_file]`, `[probability_file]`, and `[server_file]` specify the path to the file describing the edgelist of the graph, each link's availability, and the list of server nodes, respectively. `[order_file]` specifies the path to the file describing the ordering among links. Note that we already computed the link order by the path-decomposition heuristics and wrote it on `*.txt`, so `[order_file]` can be specified with the same path as `[graph_file]` when reproducing the experimental results. `<client_file>` is an optional argument that specify the path to the file describing the list of client nodes. If `<client_file>` is not specified, clients are set to all the nodes.
 
 After execution, the program computes the probability that exactly $n^\prime$ nodes are disconnected from any server node for every $n^\prime$. Note that this is equivalent to compute $U(n^\prime)$ values in our paper when the client nodes are all the nodes other than servers.
 
 _Running example:_ To compute the scale-wise unreliability of UsCarrier topology when $|T|=5$, run:
 
 ```shell
-./main ../data/0189-real-UsCarrier.edgelist.txt ../data/0189-real-UsCarrier.edgelist.txt.prob ../data/src/0189-real-UsCarrier.edgelist.txt.bc5.src ../data/0189-real-UsCarrier.edgelist.txt
+./main ../data/0186-real-UsCarrier.edgelist.txt ../data/0186-real-UsCarrier.edgelist.txt.prob ../data/src/0186-real-UsCarrier.edgelist.txt.bc5.src ../data/src/0186-real-UsCarrier.edgelist.txt
 ```
 
 The baseline method can also be executed in the same way as follows:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ After execution, the program computes the probability that exactly $n^\prime$ no
 _Running example:_ To compute the scale-wise unreliability of UsCarrier topology when $|T|=5$, run:
 
 ```shell
-./main ../data/0189-real-UsCarrier.edgelist.txt ../data/0189-real-UsCarrier.edgelist.txt.prob ../data/src/0189-real-UsCarrier.edgelist.txt.bc5.src ../data/src/0189-real-UsCarrier.edgelist.txt
+./main ../data/0189-real-UsCarrier.edgelist.txt ../data/0189-real-UsCarrier.edgelist.txt.prob ../data/src/0189-real-UsCarrier.edgelist.txt.bc5.src ../data/0189-real-UsCarrier.edgelist.txt
 ```
 
 The baseline method can also be executed in the same way as follows:


### PR DESCRIPTION
The previous code cannot set the client node set $C$ since all the experiments in the paper uses the setting $C=V$. Now the updated code can set the client node set $C$ by specifying the file describing the list of client nodes.